### PR TITLE
Implementing Standard 6492 for Signature Verification in Patch-Wallet

### DIFF
--- a/contracts/UniversalVerifier.sol
+++ b/contracts/UniversalVerifier.sol
@@ -1,0 +1,159 @@
+// As per ERC-1271
+interface IERC1271Wallet {
+    function isValidSignature(
+        bytes32 hash,
+        bytes calldata signature
+    ) external view returns (bytes4 magicValue);
+}
+
+error ERC1271Revert(bytes error);
+error ERC6492DeployFailed(bytes error);
+
+contract UniversalSigValidator {
+    bytes32 private constant ERC6492_DETECTION_SUFFIX =
+        0x6492649264926492649264926492649264926492649264926492649264926492;
+    bytes4 private constant ERC1271_SUCCESS = 0x1626ba7e;
+
+    function isValidSigImpl(
+        address _signer,
+        bytes32 _hash,
+        bytes calldata _signature,
+        bool allowSideEffects,
+        bool tryPrepare
+    ) public returns (bool) {
+        uint contractCodeLen = address(_signer).code.length;
+        bytes memory sigToValidate;
+        // The order here is striclty defined in https://eips.ethereum.org/EIPS/eip-6492
+        // - ERC-6492 suffix check and verification first, while being permissive in case the contract is already deployed; if the contract is deployed we will check the sig against the deployed version, this allows 6492 signatures to still be validated while taking into account potential key rotation
+        // - ERC-1271 verification if there's contract code
+        // - finally, ecrecover
+        bool isCounterfactual = bytes32(
+            _signature[_signature.length - 32:_signature.length]
+        ) == ERC6492_DETECTION_SUFFIX;
+        if (isCounterfactual) {
+            address create2Factory;
+            bytes memory factoryCalldata;
+            (create2Factory, factoryCalldata, sigToValidate) = abi.decode(
+                _signature[0:_signature.length - 32],
+                (address, bytes, bytes)
+            );
+
+            if (contractCodeLen == 0 || tryPrepare) {
+                (bool success, bytes memory err) = create2Factory.call(
+                    factoryCalldata
+                );
+                if (!success) revert ERC6492DeployFailed(err);
+            }
+        } else {
+            sigToValidate = _signature;
+        }
+
+        // Try ERC-1271 verification
+        if (isCounterfactual || contractCodeLen > 0) {
+            try
+                IERC1271Wallet(_signer).isValidSignature(_hash, sigToValidate)
+            returns (bytes4 magicValue) {
+                bool isValid = magicValue == ERC1271_SUCCESS;
+
+                // retry, but this time assume the prefix is a prepare call
+                if (!isValid && !tryPrepare && contractCodeLen > 0) {
+                    return
+                        isValidSigImpl(
+                            _signer,
+                            _hash,
+                            _signature,
+                            allowSideEffects,
+                            true
+                        );
+                }
+
+                if (
+                    contractCodeLen == 0 &&
+                    isCounterfactual &&
+                    !allowSideEffects
+                ) {
+                    // if the call had side effects we need to return the
+                    // result using a `revert` (to undo the state changes)
+                    assembly {
+                        mstore(0, isValid)
+                        revert(31, 1)
+                    }
+                }
+
+                return isValid;
+            } catch (bytes memory err) {
+                // retry, but this time assume the prefix is a prepare call
+                if (!tryPrepare && contractCodeLen > 0) {
+                    return
+                        isValidSigImpl(
+                            _signer,
+                            _hash,
+                            _signature,
+                            allowSideEffects,
+                            true
+                        );
+                }
+
+                revert ERC1271Revert(err);
+            }
+        }
+
+        // ecrecover verification
+        require(
+            _signature.length == 65,
+            "SignatureValidator#recoverSigner: invalid signature length"
+        );
+        bytes32 r = bytes32(_signature[0:32]);
+        bytes32 s = bytes32(_signature[32:64]);
+        uint8 v = uint8(_signature[64]);
+        if (v != 27 && v != 28) {
+            revert("SignatureValidator: invalid signature v value");
+        }
+        return ecrecover(_hash, v, r, s) == _signer;
+    }
+
+    function isValidSigWithSideEffects(
+        address _signer,
+        bytes32 _hash,
+        bytes calldata _signature
+    ) external returns (bool) {
+        return this.isValidSigImpl(_signer, _hash, _signature, true, false);
+    }
+
+    function isValidSig(
+        address _signer,
+        bytes32 _hash,
+        bytes calldata _signature
+    ) external returns (bool) {
+        try
+            this.isValidSigImpl(_signer, _hash, _signature, false, false)
+        returns (bool isValid) {
+            return isValid;
+        } catch (bytes memory error) {
+            // in order to avoid side effects from the contract getting deployed, the entire call will revert with a single byte result
+            uint len = error.length;
+            if (len == 1) return error[0] == 0x01;
+            // all other errors are simply forwarded, but in custom formats so that nothing else can revert with a single byte in the call
+            else
+                assembly {
+                    revert(error, len)
+                }
+        }
+    }
+}
+
+// this is a helper so we can perform validation in a single eth_call without pre-deploying a singleton
+contract ValidateSigOffchain {
+    constructor(address _signer, bytes32 _hash, bytes memory _signature) {
+        UniversalSigValidator validator = new UniversalSigValidator();
+        bool isValidSig = validator.isValidSigWithSideEffects(
+            _signer,
+            _hash,
+            _signature
+        );
+        assembly {
+            mstore(0, isValidSig)
+            return(31, 1)
+        }
+    }
+}

--- a/test/1271.ts
+++ b/test/1271.ts
@@ -1,47 +1,39 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { _HASHED_NAME } from "../utils/1271";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers, getChainId } from 'hardhat';
+import { _HASHED_NAME } from '../utils/1271';
+import { Contract } from 'ethers';
+import { Address, encodeAbiParameters, encodeFunctionData, keccak256, verifyMessage } from 'viem';
+import { arrayify, toUtf8Bytes, toUtf8String } from 'ethers/lib/utils';
 
-describe("1271", function () {
+describe('1271', function () {
+  let baseAccountFactory: Contract | undefined;
+
   async function deployWalletFixture() {
     const [owner] = await ethers.getSigners();
 
-    const EntryPoint = await ethers.getContractFactory("EntryPoint");
+    const EntryPoint = await ethers.getContractFactory('EntryPoint');
     const entryPoint = await EntryPoint.deploy();
 
-    const BaseAccountFactory = await ethers.getContractFactory(
-      "BaseAccountFactory"
-    );
-    const baseAccountFactory = await BaseAccountFactory.deploy(
-      entryPoint.address
-    );
+    const BaseAccountFactory = await ethers.getContractFactory('BaseAccountFactory');
+    baseAccountFactory = await BaseAccountFactory.deploy(entryPoint.address);
 
-    const receipt = await baseAccountFactory
-      .createAccount(owner.address, "0xa")
-      .then((tx: any) => tx.wait());
+    if (!baseAccountFactory) throw new Error('BaseAccountFactory not deployed');
 
-    const baseAccountAddress = receipt.events.find(
-      ({ event }: { event: string }) => event === "BaseAccountCreated"
-    ).args[0];
+    const receipt = await baseAccountFactory.createAccount(owner.address, '0xa').then((tx: any) => tx.wait());
 
-    const baseAccountContract = await ethers.getContractAt(
-      "BaseAccount",
-      baseAccountAddress
-    );
+    const baseAccountAddress = receipt.events.find(({ event }: { event: string }) => event === 'BaseAccountCreated').args[0];
 
-    const receipt2 = await baseAccountFactory
-      .createAccount(owner.address, "0xaB")
-      .then((tx: any) => tx.wait());
+    const baseAccountContract = await ethers.getContractAt('BaseAccount', baseAccountAddress);
 
-    const baseAccountAddress2 = receipt2.events.find(
-      ({ event }: { event: string }) => event === "BaseAccountCreated"
-    ).args[0];
+    const receipt2 = await baseAccountFactory.createAccount(owner.address, '0xaB').then((tx: any) => tx.wait());
 
-    const baseAccountContract2 = await ethers.getContractAt(
-      "BaseAccount",
-      baseAccountAddress2
-    );
+    const baseAccountAddress2 = receipt2.events.find(({ event }: { event: string }) => event === 'BaseAccountCreated').args[0];
+
+    const baseAccountContract2 = await ethers.getContractAt('BaseAccount', baseAccountAddress2);
+
+    const counterFactualSalt = ethers.BigNumber.from(toUtf8Bytes('IAmCounterfactualSalt'));
+    const counterFactualAddress = await baseAccountFactory.getAddress(owner.address, counterFactualSalt);
 
     return {
       baseAccountFactory,
@@ -49,85 +41,124 @@ describe("1271", function () {
       entryPoint,
       baseAccountContract,
       baseAccountContract2,
+      counterFactualSalt,
+      counterFactualAddress,
+      receipt,
+      receipt2,
     };
   }
 
-  describe("isValidSignature", function () {
-    it("should validate for correct nonces and base account addresses", async () => {
-      const { owner, baseAccountContract } = await loadFixture(
-        deployWalletFixture
+  describe('isValidSignature', function () {
+    it('check counterfactual address', async () => {
+      const { owner, counterFactualAddress, counterFactualSalt } = await loadFixture(deployWalletFixture);
+
+      const data = ethers.utils.randomBytes(32);
+      const nonce = 0;
+      // generate the domain separator for the counterfactual address
+      const domainSeparator = keccak256(
+        encodeAbiParameters(
+          [
+            { type: 'bytes32', name: 'name' },
+            { type: 'bytes32', name: 'version' },
+            { type: 'uint256', name: 'chainId' },
+            { type: 'address', name: 'address' },
+          ],
+          [
+            keccak256(toUtf8Bytes('Patch Wallet')),
+            keccak256(toUtf8Bytes('EIP712Domain(string name,uint256 chainId,address verifyingContract)')),
+            BigInt(await getChainId()),
+            counterFactualAddress,
+          ]
+        )
       );
+
+      const context = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [domainSeparator, nonce, data]));
+      const dataHashed = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32'], [data]));
+
+      const signature_1271 = await owner.signMessage(context);
+
+      const factoryCreationCalldata = baseAccountFactory!.interface.encodeFunctionData('createAccount', [
+        owner.address,
+        counterFactualSalt,
+      ]) as `0x${string}`;
+      console.log({ giveOwner: owner.address });
+      const signature_6492_account_not_created =
+        encodeAbiParameters(
+          [
+            { type: 'address', name: 'create2Factory' },
+            { type: 'bytes', name: 'factoryCalldata' },
+            { type: 'bytes', name: 'signature' },
+          ],
+          [baseAccountFactory!.address as Address, factoryCreationCalldata, signature_1271 as `0x${string}`]
+        ) + '6492'.repeat(16);
+
+      const validateOffChainContract = await ethers.getContractFactory('ValidateSigOffchain');
+
+      var validateSigOffchainBytecode = validateOffChainContract.bytecode;
+
+      const isValidSignature =
+        '0x01' ===
+        (await ethers.provider.call({
+          data: ethers.utils.concat([
+            validateSigOffchainBytecode,
+            new ethers.utils.AbiCoder().encode(['address', 'bytes32', 'bytes'], [counterFactualAddress, data, signature_6492_account_not_created]),
+          ]),
+        }));
+
+      console.log('is the sig valid: ', isValidSignature);
+    });
+
+    it('should validate for correct nonces and base account addresses', async () => {
+      const { owner, baseAccountContract } = await loadFixture(deployWalletFixture);
 
       const data = ethers.utils.randomBytes(32);
       const nonce = await baseAccountContract.nonce();
       const domainSeparator = await baseAccountContract.DOMAIN_SEPARATOR();
 
-      const context = ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(
-          ["bytes32", "uint256", "bytes32"],
-          [domainSeparator, nonce, data]
-        )
-      );
+      const context = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [domainSeparator, nonce, data]));
 
       const signature = await owner.signMessage(context);
-      const isValid = await baseAccountContract.isValidSignature(
-        data,
-        signature
-      );
+      const isValid = await baseAccountContract.isValidSignature(data, signature);
 
-      expect(isValid).to.equal("0x1626ba7e");
+      expect(isValid).to.equal('0x1626ba7e');
     });
-    it("should not validate for incorrect nonces", async () => {
-      const { owner, baseAccountContract } = await loadFixture(
-        deployWalletFixture
-      );
+
+    it('should not validate for incorrect nonces', async () => {
+      const { owner, baseAccountContract } = await loadFixture(deployWalletFixture);
 
       const data = ethers.utils.randomBytes(32);
       const nonce = (await baseAccountContract.nonce()).add(1);
 
       // Sign the data with the owner's private key
       const message = ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(
-          ["bytes32", "uint256", "bytes32"],
-          [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data]
-        )
+        ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data])
       );
       const signature = await owner.signMessage(message);
 
       // Call isValidSignature on the BaseAccount contract
-      const result = await baseAccountContract.isValidSignature(
-        data,
-        signature
-      );
+      const result = await baseAccountContract.isValidSignature(data, signature);
 
       // Check if the result is INVALID_SIG (0x00000000)
-      expect(result).to.equal("0x00000000");
+      expect(result).to.equal('0x00000000');
     });
 
-    it("should not validate for incorrect base account addresses", async function () {
-      const { owner, baseAccountContract, baseAccountContract2 } =
-        await loadFixture(deployWalletFixture);
+    it('should not validate for incorrect base account addresses', async function () {
+      const { owner, baseAccountContract, baseAccountContract2 } = await loadFixture(deployWalletFixture);
 
       const data = ethers.utils.randomBytes(32);
       const nonce = (await baseAccountContract.nonce()).add(1);
 
       // Sign the data with the owner's private key
       const message = ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(
-          ["bytes32", "uint256", "bytes32"],
-          [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data]
-        )
+        ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data])
       );
       const signature = await owner.signMessage(message);
 
       // Call isValidSignature on the BaseAccount contract
-      const result = await baseAccountContract2.isValidSignature(
-        data,
-        signature
-      );
+      const result = await baseAccountContract2.isValidSignature(data, signature);
 
       // Check if the result is INVALID_SIG (0x00000000)
-      expect(result).to.equal("0x00000000");
+      expect(result).to.equal('0x00000000');
     });
   });
 });

--- a/test/1271.ts
+++ b/test/1271.ts
@@ -1,39 +1,67 @@
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { expect } from 'chai';
-import { ethers, getChainId } from 'hardhat';
-import { _HASHED_NAME } from '../utils/1271';
-import { Contract } from 'ethers';
-import { Address, encodeAbiParameters, encodeFunctionData, keccak256, verifyMessage } from 'viem';
-import { arrayify, toUtf8Bytes, toUtf8String } from 'ethers/lib/utils';
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers, getChainId } from "hardhat";
+import { _HASHED_NAME } from "../utils/1271";
+import { Contract } from "ethers";
+import {
+  Address,
+  encodeAbiParameters,
+  encodeFunctionData,
+  keccak256,
+  verifyMessage,
+} from "viem";
+import { arrayify, toUtf8Bytes, toUtf8String } from "ethers/lib/utils";
+import exp from "constants";
 
-describe('1271', function () {
+describe("1271", function () {
   let baseAccountFactory: Contract | undefined;
 
   async function deployWalletFixture() {
-    const [owner] = await ethers.getSigners();
+    const [owner, notOwner] = await ethers.getSigners();
 
-    const EntryPoint = await ethers.getContractFactory('EntryPoint');
+    const EntryPoint = await ethers.getContractFactory("EntryPoint");
     const entryPoint = await EntryPoint.deploy();
 
-    const BaseAccountFactory = await ethers.getContractFactory('BaseAccountFactory');
+    const BaseAccountFactory = await ethers.getContractFactory(
+      "BaseAccountFactory"
+    );
     baseAccountFactory = await BaseAccountFactory.deploy(entryPoint.address);
 
-    if (!baseAccountFactory) throw new Error('BaseAccountFactory not deployed');
+    if (!baseAccountFactory) throw new Error("BaseAccountFactory not deployed");
 
-    const receipt = await baseAccountFactory.createAccount(owner.address, '0xa').then((tx: any) => tx.wait());
+    const receipt = await baseAccountFactory
+      .createAccount(owner.address, "0xa")
+      .then((tx: any) => tx.wait());
 
-    const baseAccountAddress = receipt.events.find(({ event }: { event: string }) => event === 'BaseAccountCreated').args[0];
+    const baseAccountAddress = receipt.events.find(
+      ({ event }: { event: string }) => event === "BaseAccountCreated"
+    ).args[0];
 
-    const baseAccountContract = await ethers.getContractAt('BaseAccount', baseAccountAddress);
+    const baseAccountContract = await ethers.getContractAt(
+      "BaseAccount",
+      baseAccountAddress
+    );
 
-    const receipt2 = await baseAccountFactory.createAccount(owner.address, '0xaB').then((tx: any) => tx.wait());
+    const receipt2 = await baseAccountFactory
+      .createAccount(owner.address, "0xaB")
+      .then((tx: any) => tx.wait());
 
-    const baseAccountAddress2 = receipt2.events.find(({ event }: { event: string }) => event === 'BaseAccountCreated').args[0];
+    const baseAccountAddress2 = receipt2.events.find(
+      ({ event }: { event: string }) => event === "BaseAccountCreated"
+    ).args[0];
 
-    const baseAccountContract2 = await ethers.getContractAt('BaseAccount', baseAccountAddress2);
+    const baseAccountContract2 = await ethers.getContractAt(
+      "BaseAccount",
+      baseAccountAddress2
+    );
 
-    const counterFactualSalt = ethers.BigNumber.from(toUtf8Bytes('IAmCounterfactualSalt'));
-    const counterFactualAddress = await baseAccountFactory.getAddress(owner.address, counterFactualSalt);
+    const counterFactualSalt = ethers.BigNumber.from(
+      toUtf8Bytes("IAmCounterfactualSalt")
+    );
+    const counterFactualAddress = await baseAccountFactory.getAddress(
+      owner.address,
+      counterFactualSalt
+    );
 
     return {
       baseAccountFactory,
@@ -45,120 +73,333 @@ describe('1271', function () {
       counterFactualAddress,
       receipt,
       receipt2,
+      notOwner,
     };
   }
 
-  describe('isValidSignature', function () {
-    it('check counterfactual address', async () => {
-      const { owner, counterFactualAddress, counterFactualSalt } = await loadFixture(deployWalletFixture);
+  describe("isValidSignature", function () {
+    it("check counterfactual address", async () => {
+      const { owner, counterFactualAddress, counterFactualSalt } =
+        await loadFixture(deployWalletFixture);
+
+      // dummy data
+      const data = ethers.utils.randomBytes(32);
+
+      // generate the signing context using the data
+      const nonce = 0;
+      const domainSeparator = keccak256(
+        encodeAbiParameters(
+          [
+            { type: "bytes32", name: "name" },
+            { type: "bytes32", name: "version" },
+            { type: "uint256", name: "chainId" },
+            { type: "address", name: "address" },
+          ],
+          [
+            keccak256(toUtf8Bytes("Patch Wallet")),
+            keccak256(
+              toUtf8Bytes(
+                "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+              )
+            ),
+            BigInt(await getChainId()),
+            counterFactualAddress,
+          ]
+        )
+      );
+      const context = ethers.utils.arrayify(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [domainSeparator, nonce, data]
+        )
+      );
+
+      const signature_1271 = await owner.signMessage(context);
+
+      // get the calldata to create the base account using the factory
+      const factoryCreationCalldata =
+        baseAccountFactory!.interface.encodeFunctionData("createAccount", [
+          owner.address,
+          counterFactualSalt,
+        ]) as `0x${string}`;
+
+      // Create the wrapping for the 6492 Signature (TYPE 2: account not created see: https://eips.ethereum.org/EIPS/eip-6492)
+      const signature_6492_account_not_created =
+        encodeAbiParameters(
+          [
+            { type: "address", name: "create2Factory" },
+            { type: "bytes", name: "factoryCalldata" },
+            { type: "bytes", name: "signature" },
+          ],
+          [
+            baseAccountFactory!.address as Address,
+            factoryCreationCalldata,
+            signature_1271 as `0x${string}`,
+          ]
+          // the "MagicBytes" are used to detect 6492 signatures. They consist of 64 Characters (32 bytes) that say "6492"
+        ) + "6492".repeat(16);
+
+      // getting the bytecode of the ValidateSigOffchain contract
+      const validateOffChainContract = await ethers.getContractFactory(
+        "ValidateSigOffchain"
+      );
+      var validateSigOffchainBytecode = validateOffChainContract.bytecode;
+
+      // Magic happens here: we create the ValidateSigOffchain contract using a call, the constructor deploys the verificator contract, and we call the verify function
+      // 1. Deploy OffChainContract
+      // 2. its constructor creates the OnChainContract (within a free eth_call)
+      // 3. The verify function is called on the OnChainContract
+      // 4. The OnChainContract returns the result to the OffChainContract
+      // 5. The OffChainContract returns the result to the caller (which is the result of the verify function)
+      // This solution allows us to use the 6492 for free (no gas costs) and without deploying the OnChainContract
+      const isValidSignature =
+        "0x01" ===
+        (await ethers.provider.call({
+          data: ethers.utils.concat([
+            validateSigOffchainBytecode,
+            new ethers.utils.AbiCoder().encode(
+              ["address", "bytes32", "bytes"],
+              [counterFactualAddress, data, signature_6492_account_not_created]
+            ),
+          ]),
+        }));
+
+      // check if the signature is valid
+      expect(isValidSignature).to.equal(true);
+    });
+
+    it("check counterfactual address (bad nonce)", async () => {
+      const { owner, counterFactualAddress, counterFactualSalt } =
+        await loadFixture(deployWalletFixture);
 
       const data = ethers.utils.randomBytes(32);
-      const nonce = 0;
+      const nonce = 1;
       // generate the domain separator for the counterfactual address
       const domainSeparator = keccak256(
         encodeAbiParameters(
           [
-            { type: 'bytes32', name: 'name' },
-            { type: 'bytes32', name: 'version' },
-            { type: 'uint256', name: 'chainId' },
-            { type: 'address', name: 'address' },
+            { type: "bytes32", name: "name" },
+            { type: "bytes32", name: "version" },
+            { type: "uint256", name: "chainId" },
+            { type: "address", name: "address" },
           ],
           [
-            keccak256(toUtf8Bytes('Patch Wallet')),
-            keccak256(toUtf8Bytes('EIP712Domain(string name,uint256 chainId,address verifyingContract)')),
+            keccak256(toUtf8Bytes("Patch Wallet")),
+            keccak256(
+              toUtf8Bytes(
+                "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+              )
+            ),
             BigInt(await getChainId()),
             counterFactualAddress,
           ]
         )
       );
 
-      const context = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [domainSeparator, nonce, data]));
-      const dataHashed = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32'], [data]));
+      const context = ethers.utils.arrayify(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [domainSeparator, nonce, data]
+        )
+      );
 
       const signature_1271 = await owner.signMessage(context);
 
-      const factoryCreationCalldata = baseAccountFactory!.interface.encodeFunctionData('createAccount', [
-        owner.address,
-        counterFactualSalt,
-      ]) as `0x${string}`;
-      console.log({ giveOwner: owner.address });
+      const factoryCreationCalldata =
+        baseAccountFactory!.interface.encodeFunctionData("createAccount", [
+          owner.address,
+          counterFactualSalt,
+        ]) as `0x${string}`;
+
       const signature_6492_account_not_created =
         encodeAbiParameters(
           [
-            { type: 'address', name: 'create2Factory' },
-            { type: 'bytes', name: 'factoryCalldata' },
-            { type: 'bytes', name: 'signature' },
+            { type: "address", name: "create2Factory" },
+            { type: "bytes", name: "factoryCalldata" },
+            { type: "bytes", name: "signature" },
           ],
-          [baseAccountFactory!.address as Address, factoryCreationCalldata, signature_1271 as `0x${string}`]
-        ) + '6492'.repeat(16);
+          [
+            baseAccountFactory!.address as Address,
+            factoryCreationCalldata,
+            signature_1271 as `0x${string}`,
+          ]
+        ) + "6492".repeat(16);
 
-      const validateOffChainContract = await ethers.getContractFactory('ValidateSigOffchain');
+      const validateOffChainContract = await ethers.getContractFactory(
+        "ValidateSigOffchain"
+      );
 
       var validateSigOffchainBytecode = validateOffChainContract.bytecode;
 
       const isValidSignature =
-        '0x01' ===
+        "0x01" ===
         (await ethers.provider.call({
           data: ethers.utils.concat([
             validateSigOffchainBytecode,
-            new ethers.utils.AbiCoder().encode(['address', 'bytes32', 'bytes'], [counterFactualAddress, data, signature_6492_account_not_created]),
+            new ethers.utils.AbiCoder().encode(
+              ["address", "bytes32", "bytes"],
+              [counterFactualAddress, data, signature_6492_account_not_created]
+            ),
           ]),
         }));
 
-      console.log('is the sig valid: ', isValidSignature);
+      expect(isValidSignature).to.equal(false);
     });
 
-    it('should validate for correct nonces and base account addresses', async () => {
-      const { owner, baseAccountContract } = await loadFixture(deployWalletFixture);
+    it("check counterfactual address (bad signer)", async () => {
+      const { notOwner, owner, counterFactualAddress, counterFactualSalt } =
+        await loadFixture(deployWalletFixture);
+
+      const data = ethers.utils.randomBytes(32);
+      const nonce = 1;
+      // generate the domain separator for the counterfactual address
+      const domainSeparator = keccak256(
+        encodeAbiParameters(
+          [
+            { type: "bytes32", name: "name" },
+            { type: "bytes32", name: "version" },
+            { type: "uint256", name: "chainId" },
+            { type: "address", name: "address" },
+          ],
+          [
+            keccak256(toUtf8Bytes("Patch Wallet")),
+            keccak256(
+              toUtf8Bytes(
+                "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+              )
+            ),
+            BigInt(await getChainId()),
+            counterFactualAddress,
+          ]
+        )
+      );
+
+      const context = ethers.utils.arrayify(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [domainSeparator, nonce, data]
+        )
+      );
+
+      const signature_1271 = await notOwner.signMessage(context);
+
+      const factoryCreationCalldata =
+        baseAccountFactory!.interface.encodeFunctionData("createAccount", [
+          owner.address,
+          counterFactualSalt,
+        ]) as `0x${string}`;
+
+      const signature_6492_account_not_created =
+        encodeAbiParameters(
+          [
+            { type: "address", name: "create2Factory" },
+            { type: "bytes", name: "factoryCalldata" },
+            { type: "bytes", name: "signature" },
+          ],
+          [
+            baseAccountFactory!.address as Address,
+            factoryCreationCalldata,
+            signature_1271 as `0x${string}`,
+          ]
+        ) + "6492".repeat(16);
+
+      const validateOffChainContract = await ethers.getContractFactory(
+        "ValidateSigOffchain"
+      );
+
+      var validateSigOffchainBytecode = validateOffChainContract.bytecode;
+
+      const isValidSignature =
+        "0x01" ===
+        (await ethers.provider.call({
+          data: ethers.utils.concat([
+            validateSigOffchainBytecode,
+            new ethers.utils.AbiCoder().encode(
+              ["address", "bytes32", "bytes"],
+              [counterFactualAddress, data, signature_6492_account_not_created]
+            ),
+          ]),
+        }));
+
+      expect(isValidSignature).to.equal(false);
+    });
+
+    it("should validate for correct nonces and base account addresses", async () => {
+      const { owner, baseAccountContract } = await loadFixture(
+        deployWalletFixture
+      );
 
       const data = ethers.utils.randomBytes(32);
       const nonce = await baseAccountContract.nonce();
       const domainSeparator = await baseAccountContract.DOMAIN_SEPARATOR();
 
-      const context = ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [domainSeparator, nonce, data]));
+      const context = ethers.utils.arrayify(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [domainSeparator, nonce, data]
+        )
+      );
 
       const signature = await owner.signMessage(context);
-      const isValid = await baseAccountContract.isValidSignature(data, signature);
+      const isValid = await baseAccountContract.isValidSignature(
+        data,
+        signature
+      );
 
-      expect(isValid).to.equal('0x1626ba7e');
+      expect(isValid).to.equal("0x1626ba7e");
     });
 
-    it('should not validate for incorrect nonces', async () => {
-      const { owner, baseAccountContract } = await loadFixture(deployWalletFixture);
+    it("should not validate for incorrect nonces", async () => {
+      const { owner, baseAccountContract } = await loadFixture(
+        deployWalletFixture
+      );
 
       const data = ethers.utils.randomBytes(32);
       const nonce = (await baseAccountContract.nonce()).add(1);
 
       // Sign the data with the owner's private key
       const message = ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data])
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data]
+        )
       );
       const signature = await owner.signMessage(message);
 
       // Call isValidSignature on the BaseAccount contract
-      const result = await baseAccountContract.isValidSignature(data, signature);
+      const result = await baseAccountContract.isValidSignature(
+        data,
+        signature
+      );
 
       // Check if the result is INVALID_SIG (0x00000000)
-      expect(result).to.equal('0x00000000');
+      expect(result).to.equal("0x00000000");
     });
 
-    it('should not validate for incorrect base account addresses', async function () {
-      const { owner, baseAccountContract, baseAccountContract2 } = await loadFixture(deployWalletFixture);
+    it("should not validate for incorrect base account addresses", async function () {
+      const { owner, baseAccountContract, baseAccountContract2 } =
+        await loadFixture(deployWalletFixture);
 
       const data = ethers.utils.randomBytes(32);
       const nonce = (await baseAccountContract.nonce()).add(1);
 
       // Sign the data with the owner's private key
       const message = ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes32'], [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data])
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint256", "bytes32"],
+          [await baseAccountContract.DOMAIN_SEPARATOR(), nonce, data]
+        )
       );
       const signature = await owner.signMessage(message);
 
       // Call isValidSignature on the BaseAccount contract
-      const result = await baseAccountContract2.isValidSignature(data, signature);
+      const result = await baseAccountContract2.isValidSignature(
+        data,
+        signature
+      );
 
       // Check if the result is INVALID_SIG (0x00000000)
-      expect(result).to.equal('0x00000000');
+      expect(result).to.equal("0x00000000");
     });
   });
 });

--- a/utils/signing.ts
+++ b/utils/signing.ts
@@ -1,36 +1,67 @@
-import { _TypedDataEncoder, keccak256, solidityPack, toUtf8Bytes, defaultAbiCoder, BytesLike, solidityKeccak256 } from 'ethers/lib/utils';
-import { OperationType } from 'ethers-multisend';
-import { ecsign } from 'ethereumjs-util';
-import { Contract } from 'ethers';
-import { Address } from 'hardhat-deploy/types';
+import {
+  _TypedDataEncoder,
+  keccak256,
+  solidityPack,
+  toUtf8Bytes,
+  defaultAbiCoder,
+  BytesLike,
+  solidityKeccak256,
+} from "ethers/lib/utils";
+import { OperationType } from "ethers-multisend";
+import { ecsign } from "ethereumjs-util";
+import { Contract } from "ethers";
+import { Address } from "hardhat-deploy/types";
 
-export const ownerPK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+export const ownerPK =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
 const convertToHash = (text: string) => {
   return keccak256(toUtf8Bytes(text));
 };
 
-const DOMAIN_SEPARATOR_SIGNATURE_HASH = convertToHash('EIP712Domain(uint256 chainId,address verifyingContract)');
+const DOMAIN_SEPARATOR_SIGNATURE_HASH = convertToHash(
+  "EIP712Domain(uint256 chainId,address verifyingContract)"
+);
 
-const CREATE_TRANSACTION_TYPEHASH = convertToHash('CreateTransaction(address to,uint256 value,bytes data,uint8 operation)');
+const CREATE_TRANSACTION_TYPEHASH = convertToHash(
+  "CreateTransaction(address to,uint256 value,bytes data,uint8 operation)"
+);
 
 const getChainId = async (contract: Contract): Promise<number> => {
   return (await contract.provider.getNetwork()).chainId;
 };
 
 function getDomainSeparator(modifierAddress: Address, chainId: number): string {
-  return keccak256(defaultAbiCoder.encode(['bytes32', 'uint256', 'address'], [DOMAIN_SEPARATOR_SIGNATURE_HASH, chainId, modifierAddress]));
+  return keccak256(
+    defaultAbiCoder.encode(
+      ["bytes32", "uint256", "address"],
+      [DOMAIN_SEPARATOR_SIGNATURE_HASH, chainId, modifierAddress]
+    )
+  );
 }
 
-async function getTransactionDigest(trustedTxModifier: Contract, to: Address, value: string, data: string, operation: OperationType, nonce: number) {
-  const DOMAIN_SEPARATOR = getDomainSeparator(trustedTxModifier.address, await getChainId(trustedTxModifier));
+async function getTransactionDigest(
+  trustedTxModifier: Contract,
+  to: Address,
+  value: string,
+  data: string,
+  operation: OperationType,
+  nonce: number
+) {
+  const DOMAIN_SEPARATOR = getDomainSeparator(
+    trustedTxModifier.address,
+    await getChainId(trustedTxModifier)
+  );
 
   const msg = defaultAbiCoder.encode(
-    ['bytes32', 'address', 'uint256', 'bytes', 'uint8', 'uint256'],
+    ["bytes32", "address", "uint256", "bytes", "uint8", "uint256"],
     [CREATE_TRANSACTION_TYPEHASH, to, value, data, operation, nonce]
   );
 
-  const pack = solidityPack(['bytes1', 'bytes1', 'bytes32', 'bytes32'], ['0x19', '0x01', DOMAIN_SEPARATOR, keccak256(msg)]);
+  const pack = solidityPack(
+    ["bytes1", "bytes1", "bytes32", "bytes32"],
+    ["0x19", "0x01", DOMAIN_SEPARATOR, keccak256(msg)]
+  );
   return keccak256(pack);
 }
 
@@ -43,16 +74,34 @@ export async function getSignedTransaction(
   operation: OperationType,
   nonce: number
 ) {
-  const digest = await getTransactionDigest(trustedTxModifier, to, value, data, operation, nonce);
-  const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(privateKey.replace('0x', ''), 'hex'));
+  const digest = await getTransactionDigest(
+    trustedTxModifier,
+    to,
+    value,
+    data,
+    operation,
+    nonce
+  );
+  const { v, r, s } = ecsign(
+    Buffer.from(digest.slice(2), "hex"),
+    Buffer.from(privateKey.replace("0x", ""), "hex")
+  );
 
   const signedTransaction = { to, value, data, operation, nonce, v, r, s };
 
   return signedTransaction;
 }
 
-function encodeTransaction(to: Address, value: Number, data: BytesLike, operation: Number): string {
-  return defaultAbiCoder.encode(['address', 'uint256', 'bytes', 'uint8'], [to, value, data, operation]);
+function encodeTransaction(
+  to: Address,
+  value: Number,
+  data: BytesLike,
+  operation: Number
+): string {
+  return defaultAbiCoder.encode(
+    ["address", "uint256", "bytes", "uint8"],
+    [to, value, data, operation]
+  );
 }
 
 export function getMessageHash(
@@ -65,7 +114,7 @@ export function getMessageHash(
   operation: Number
 ): string {
   return solidityKeccak256(
-    ['address', 'uint256', 'bytes4', 'bytes'],
+    ["address", "uint256", "bytes4", "bytes"],
     [
       trustedTxModifierContract.address,
       nonce,

--- a/utils/signing.ts
+++ b/utils/signing.ts
@@ -1,67 +1,36 @@
-import {
-  _TypedDataEncoder,
-  keccak256,
-  solidityPack,
-  toUtf8Bytes,
-  defaultAbiCoder,
-  BytesLike,
-  solidityKeccak256,
-} from "ethers/lib/utils";
-import { OperationType } from "ethers-multisend";
-import { ecsign } from "ethereumjs-util";
-import { Contract } from "ethers";
-import { Address } from "hardhat-deploy/types";
+import { _TypedDataEncoder, keccak256, solidityPack, toUtf8Bytes, defaultAbiCoder, BytesLike, solidityKeccak256 } from 'ethers/lib/utils';
+import { OperationType } from 'ethers-multisend';
+import { ecsign } from 'ethereumjs-util';
+import { Contract } from 'ethers';
+import { Address } from 'hardhat-deploy/types';
 
-export const ownerPK =
-  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+export const ownerPK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
 const convertToHash = (text: string) => {
   return keccak256(toUtf8Bytes(text));
 };
 
-const DOMAIN_SEPARATOR_SIGNATURE_HASH = convertToHash(
-  "EIP712Domain(uint256 chainId,address verifyingContract)"
-);
+const DOMAIN_SEPARATOR_SIGNATURE_HASH = convertToHash('EIP712Domain(uint256 chainId,address verifyingContract)');
 
-const CREATE_TRANSACTION_TYPEHASH = convertToHash(
-  "CreateTransaction(address to,uint256 value,bytes data,uint8 operation)"
-);
+const CREATE_TRANSACTION_TYPEHASH = convertToHash('CreateTransaction(address to,uint256 value,bytes data,uint8 operation)');
 
 const getChainId = async (contract: Contract): Promise<number> => {
   return (await contract.provider.getNetwork()).chainId;
 };
 
 function getDomainSeparator(modifierAddress: Address, chainId: number): string {
-  return keccak256(
-    defaultAbiCoder.encode(
-      ["bytes32", "uint256", "address"],
-      [DOMAIN_SEPARATOR_SIGNATURE_HASH, chainId, modifierAddress]
-    )
-  );
+  return keccak256(defaultAbiCoder.encode(['bytes32', 'uint256', 'address'], [DOMAIN_SEPARATOR_SIGNATURE_HASH, chainId, modifierAddress]));
 }
 
-async function getTransactionDigest(
-  trustedTxModifier: Contract,
-  to: Address,
-  value: string,
-  data: string,
-  operation: OperationType,
-  nonce: number
-) {
-  const DOMAIN_SEPARATOR = getDomainSeparator(
-    trustedTxModifier.address,
-    await getChainId(trustedTxModifier)
-  );
+async function getTransactionDigest(trustedTxModifier: Contract, to: Address, value: string, data: string, operation: OperationType, nonce: number) {
+  const DOMAIN_SEPARATOR = getDomainSeparator(trustedTxModifier.address, await getChainId(trustedTxModifier));
 
   const msg = defaultAbiCoder.encode(
-    ["bytes32", "address", "uint256", "bytes", "uint8", "uint256"],
+    ['bytes32', 'address', 'uint256', 'bytes', 'uint8', 'uint256'],
     [CREATE_TRANSACTION_TYPEHASH, to, value, data, operation, nonce]
   );
 
-  const pack = solidityPack(
-    ["bytes1", "bytes1", "bytes32", "bytes32"],
-    ["0x19", "0x01", DOMAIN_SEPARATOR, keccak256(msg)]
-  );
+  const pack = solidityPack(['bytes1', 'bytes1', 'bytes32', 'bytes32'], ['0x19', '0x01', DOMAIN_SEPARATOR, keccak256(msg)]);
   return keccak256(pack);
 }
 
@@ -74,34 +43,16 @@ export async function getSignedTransaction(
   operation: OperationType,
   nonce: number
 ) {
-  const digest = await getTransactionDigest(
-    trustedTxModifier,
-    to,
-    value,
-    data,
-    operation,
-    nonce
-  );
-  const { v, r, s } = ecsign(
-    Buffer.from(digest.slice(2), "hex"),
-    Buffer.from(privateKey.replace("0x", ""), "hex")
-  );
+  const digest = await getTransactionDigest(trustedTxModifier, to, value, data, operation, nonce);
+  const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(privateKey.replace('0x', ''), 'hex'));
 
   const signedTransaction = { to, value, data, operation, nonce, v, r, s };
 
   return signedTransaction;
 }
 
-function encodeTransaction(
-  to: Address,
-  value: Number,
-  data: BytesLike,
-  operation: Number
-): string {
-  return defaultAbiCoder.encode(
-    ["address", "uint256", "bytes", "uint8"],
-    [to, value, data, operation]
-  );
+function encodeTransaction(to: Address, value: Number, data: BytesLike, operation: Number): string {
+  return defaultAbiCoder.encode(['address', 'uint256', 'bytes', 'uint8'], [to, value, data, operation]);
 }
 
 export function getMessageHash(
@@ -114,7 +65,7 @@ export function getMessageHash(
   operation: Number
 ): string {
   return solidityKeccak256(
-    ["address", "uint256", "bytes4", "bytes"],
+    ['address', 'uint256', 'bytes4', 'bytes'],
     [
       trustedTxModifierContract.address,
       nonce,


### PR DESCRIPTION
**Description:**

This pull request proposes enhancements to the patch-wallet to align it with Standard 6492, addressing the limitations of counterfactual contracts as highlighted in `ERC-1271`.

**Background:**

As the adoption of account abstraction grows, deferring contract deployment until the user's first transaction has become an optimal user experience. This, however, poses a challenge when dApps require signatures not only for transactions but for simple actions like logging in. With the current constraints of `ERC-1271`, contract wallets cannot sign messages before their actual deployment. Standard `ERC-6492` is designed to overcome this limitation.

**Implementation Details:**

Our solution offers a seamless method to verify both traditional factual wallets using the existing `ERC-1271` signatures and the new counterfactual (pre-deployement) wallet using the proposed [6492 standard](https://eips.ethereum.org/EIPS/eip-6492).

**1. Signature Generation**: First, a standard `ERC-1271` signature is generated.
**2. Deployment Check**: We then verify if the wallet has already been deployed.
**3. Signature Wrapping**:
    - If the wallet is already deployed, the original `ERC-1271` signature is returned.
    - If not, the signature is wrapped to conform to the `ERC-6492` standard.

**Verification:**

For verification, both `ERC-1271` and `ERC-6492` signatures undergo the same process. The `offChainVerificator` is designed to discern between the two signatures, ensuring no additional overhead on the verifier's end.

**Backward Compatibility:**

Importantly, this implementation is backward compatible. No changes are made on-chain, ensuring that current contract implementations remain unaffected.

